### PR TITLE
Customized column width and pagination

### DIFF
--- a/jspdf.plugin.table.js
+++ b/jspdf.plugin.table.js
@@ -28,11 +28,11 @@ var defaultConfig = {
 	marginright : 20,
 	xOffset : 10,
 	yOffset : 10,
-	marginbottom:50,
-	paginationX: 10,
-	paginationY: 10,
-	pagina:1,
-	columnWidth:null
+	marginbottom:50,//extra margin bottom to correct page overflows with big amount of data.
+	pagetionX: 10,//Coordinate X for pagination
+	pagetionY: 10,//Coordinate Y for pagination
+	page:1,//count for pages (maybe move this to other position)
+	columnWidth:null//array for customize colums widht. Example: columnWidth:[20,100,100]. all columns in table should be defiend
 };
 
 //draws table on the document
@@ -72,16 +72,16 @@ jsPDFAPI.drawTable = function(table_DATA,config) {
 			initPDF(tabledata, defaultConfig, false);
 			j = cSplitIndex[i];
 			if ((i + 1) != cSplitIndex.length) {
-				//pagina inicial
-				if(defaultConfig.pagina == 1){
-					doc.text(defaultConfig.paginationX,defaultConfig.paginationY,defaultConfig.pagina.toString());
-					defaultConfig.pagina++;
+				//first page
+				if(defaultConfig.page == 1){
+					doc.text(defaultConfig.pagetionX,defaultConfig.pagetionY,defaultConfig.page.toString());
+					defaultConfig.page++;
 				}
 				doc.addPage();
 				
-				//resto de paginas
-				doc.text(defaultConfig.paginationX,defaultConfig.paginationY,defaultConfig.pagina.toString());
-				defaultConfig.pagina++;
+				//rest pages
+				doc.text(defaultConfig.pagetionX,defaultConfig.pagetionY,defaultConfig.page.toString());
+				defaultConfig.page++;
 				
 			}
 		}
@@ -164,6 +164,7 @@ function initPDF(data, marginConfig, firstpage) {
 	height = dimensions[2] / rowCount;
 	dimensions[3] = calculateDim(data, dimensions);
 	
+	//if customized colums widht is set, sum all new widhts
 	if(defaultConfig.columnWidth != null){
 		sum = 0;
 		for(count = 0;count< columnCount ;count++){
@@ -209,11 +210,15 @@ function insertData(rowCount, columnCount, dimensions, data, brControl) {
 	for (var i = 0; i < rowCount; i++) {
 		obj = data[i];
 		x = dimensions[0] + xOffset;
+		
+		//index for columnWidth
 		var i_col = 0;
+		
 		for (var key in obj) {
 			if (obj.hasOwnProperty(key)) {
 
 				cell = (obj[key] ? obj[key] : '-') + '';
+				//new case for customized columnWidth. 
 				if( defaultConfig.columnWidth != null){
 					if (((cell.length * fontSize) + xOffset) > (defaultConfig.columnWidth[i_col])) {
 						iTexts = cell.length * fontSize;
@@ -293,10 +298,9 @@ function drawColumns(i, dimensions) {
 	var h = dimensions[3];
 
 	for (var j = 0; j < i; j++) {
+		//if defined customized columnWidth
 		if(defaultConfig.columnWidth != null){
-		//$('.buscador').append(i+' - '+defaultConfig.columnWidth.length + ' - '+ defaultConfig.columnWidth[j]+'<br>');
-	
-		w= defaultConfig.columnWidth[j];
+			w= defaultConfig.columnWidth[j];
 		}
 	
 		doc.rect(x, y, w, h);
@@ -345,6 +349,7 @@ function calculateDim(data, dimensions) {
 	for (var i = 0; i < heights.length; i++) {
 		value += heights[i];
 		indexHelper += heights[i];
+		
 		if (indexHelper > (doc.internal.pageSize.height-defaultConfig.marginbottom - pageStart)) {
 			SplitIndex.push(i);
 			indexHelper = 0;


### PR DESCRIPTION
I try to translate all the changes in the file to english, but i maybe forget one or two, tell me if that's the case. 

New features:
-Page counter when multiple pages:
    page,// global page count
    paginationX: 10, // Coordinate X
    paginationY: 10, // Coordinate Y

-Extra bottom space (height). In very big tables, when the text need multiple lines, some rows dissapear in the bottom. I use this to show less columns per page (or add some space for the pagination counter).
    marginbottom:50,

-Customized column width: To personalize all columns individually
    columnWidth:null //as an array [c1widht,...,cNwidht], or null. All clumns should be defined

////////////////////////////////////////////////////////////////////////////////////////////////////////
/*Example for a 7 column table with jquery
function generateTablePDF() {

```
var fileTitle = 'Example';

doc = new jsPDF('l', 'pt', 'a4', true);
doc.setFont("courier", "normal");
doc.setFontSize(15);

doc.text(10,20,fileTitle);

doc.setFontSize(8);
data=doc.tableToJson($('table').attr('id'));
height = doc.drawTable(data,{
    xstart:10,
    ystart:10,
    tablestart:40,
    marginleft:10,
    marginright:-10,
    paginacionX:800,
    paginacionY:575,
    columnWidth:[50,100,100,50,100,100,100]

});

doc.save(fileTitle+".pdf");
```

}
*/
